### PR TITLE
feat: add flow permission check on user processes lists

### DIFF
--- a/processlib/services.py
+++ b/processlib/services.py
@@ -1,7 +1,7 @@
 from django.db.models import Q
 from django.utils import timezone
 
-from .flow import get_flow
+from .flow import get_flow, get_flows
 from .models import Process, ActivityInstance
 
 
@@ -99,12 +99,7 @@ def get_user_processes(user, include_unassigned=True):
             _activity_instances__assigned_group__isnull=True,
         ) & ~Q(_activity_instances__status=ActivityInstance.STATUS_CANCELED)
 
-    processes = Process.objects.filter(
-        status=Process.STATUS_STARTED,
-    ).filter(q).distinct()
-    for process in processes:
-        if not user_has_any_process_perm(user, process):
-            processes = processes.exclude(pk=process.pk)
+    q = filter_by_permissions(q, user)
     return Process.objects.filter(q).distinct()
 
 
@@ -133,13 +128,19 @@ def get_user_current_processes(user, include_unassigned=True):
             ),
         )
 
-    processes = Process.objects.filter(
+    q = filter_by_permissions(q, user)
+    return Process.objects.filter(
         status=Process.STATUS_STARTED,
     ).filter(q).distinct()
-    for process in processes:
-        if not user_has_any_process_perm(user, process):
-            processes = processes.exclude(pk=process.pk)
-    return Process.objects.filter(status=Process.STATUS_STARTED).filter(q).distinct()
+
+
+def filter_by_permissions(q, user):
+    flows = get_flows()
+    flows_label_list = [flow[0] for flow in flows if not flow[1].permission or user.has_perm(flow[1].permission)]
+    q &= Q(
+        _activity_instances__process__flow_label__in=flows_label_list
+    )
+    return q
 
 
 def user_has_any_process_perm(user, process):

--- a/processlib/services.py
+++ b/processlib/services.py
@@ -99,6 +99,12 @@ def get_user_processes(user, include_unassigned=True):
             _activity_instances__assigned_group__isnull=True,
         ) & ~Q(_activity_instances__status=ActivityInstance.STATUS_CANCELED)
 
+    processes = Process.objects.filter(
+        status=Process.STATUS_STARTED,
+    ).filter(q).distinct()
+    for process in processes:
+        if not user_has_any_process_perm(user, process):
+            processes = processes.exclude(pk=process.pk)
     return Process.objects.filter(q).distinct()
 
 
@@ -127,6 +133,12 @@ def get_user_current_processes(user, include_unassigned=True):
             ),
         )
 
+    processes = Process.objects.filter(
+        status=Process.STATUS_STARTED,
+    ).filter(q).distinct()
+    for process in processes:
+        if not user_has_any_process_perm(user, process):
+            processes = processes.exclude(pk=process.pk)
     return Process.objects.filter(status=Process.STATUS_STARTED).filter(q).distinct()
 
 

--- a/processlib/test_settings.py
+++ b/processlib/test_settings.py
@@ -4,14 +4,13 @@ INSTALLED_APPS = [
     "django.contrib.contenttypes",
     "django.contrib.auth",
     "django.contrib.sessions",
-
     "processlib",
 ]
 
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': ':memory:',
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": ":memory:",
     }
 }
 
@@ -22,9 +21,12 @@ MIDDLEWARE = [
 
 TEMPLATES = [
     {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'APP_DIRS': True,
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": ["django.template.context_processors.request"]
+        },
     },
 ]
 
-ROOT_URLCONF = 'processlib.test_urls'
+ROOT_URLCONF = "processlib.test_urls"

--- a/processlib/tests.py
+++ b/processlib/tests.py
@@ -22,6 +22,9 @@ from .services import user_has_activity_perm, user_has_any_process_perm
 from .views import (
     ProcessUpdateView,
     ProcessDetailView,
+    ProcessListView,
+    UserProcessListView,
+    UserCurrentProcessListView,
     ProcessCancelView,
     ProcessStartView,
     ProcessActivityView,
@@ -390,6 +393,45 @@ class ProcesslibViewPermissionTest(TestCase):
         self.post_with_permissions = RequestFactory().post("/")
         self.post_with_permissions.user = self.user_with_perms
 
+    def test_process_list_view_respects_flow_permission(
+        self
+    ):
+        no_perm_response = ProcessListView.as_view()(
+            self.get_no_permissions,
+        )
+        self.assertNotContains(no_perm_response, self.process.pk)
+
+        perm_response = ProcessListView.as_view()(
+            self.get_with_permissions,
+        )
+        self.assertContains(perm_response, self.process.pk)
+
+    def test_user_process_list_view_respects_flow_permission(
+            self
+    ):
+        no_perm_response = UserProcessListView.as_view()(
+            self.get_no_permissions,
+        )
+        self.assertNotContains(no_perm_response, self.process.pk)
+
+        perm_response = UserProcessListView.as_view()(
+            self.get_with_permissions,
+        )
+        self.assertContains(perm_response, self.process.pk)
+
+    def test_user_current_process_list_view_respects_flow_permission(
+            self
+    ):
+        no_perm_response = UserCurrentProcessListView.as_view()(
+            self.get_no_permissions,
+        )
+        self.assertNotContains(no_perm_response, self.process.pk)
+
+        perm_response = UserCurrentProcessListView.as_view()(
+            self.get_with_permissions,
+        )
+        self.assertContains(perm_response, self.process.pk)
+
     def test_process_detail_view_raises_permission_denied_with_missing_permissions(
         self
     ):
@@ -709,6 +751,15 @@ class ProcesslibViewTest(TestCase):
                 activity_name="start", modified_by=self.user
             ).first()
         )
+
+    def test_process_list(self):
+        url = reverse(
+            "processlib:process-list",
+        )
+        response = self.client.get(url)
+
+        self.assertContains(response, "view_test_flow")
+        self.assertContains(response, str(self.process.pk))
 
 
 class ActivityTest(TestCase):


### PR DESCRIPTION
We need a addition regarding to permission check. A flow should be only in useres list if the user has any permission on this flow, so we do not have to set a group for permission checks.

The suggestions uses the ''user_has_any_process_perm'' function to avoid visibility issues due to the current solution. 